### PR TITLE
Fixed question_loaders default directory names.

### DIFF
--- a/lllm/questions_loaders.py
+++ b/lllm/questions_loaders.py
@@ -278,7 +278,7 @@ class QuestionsLoader(DataFrame, ABC):
         # get the current working directory
         cwd = os.getcwd()
         steps_up = 0
-        while os.path.basename(cwd) not in ["lie_detection", "LLM_lie_detection"]:
+        while os.path.basename(cwd) not in ["lie_detection", "LLM_lie_detection", "LLM-LieDetector"]:
             cwd = os.path.dirname(cwd)
             steps_up += 1
         # now cwd is the root directory


### PR DESCRIPTION
Currently, the QuestionLoader class's path_prefix method gets stuck in an infinite loop because of this while condition:

`while os.path.basename(cwd) not in ["lie_detection", "LLM_lie_detection"]:`

but for people who clone this repositories, the project root directory may be automatically named as “LLM-LieDetector", so path_prefix will never find any directory and get stuck in a loop. Adding “LLM-LieDetector" to the list of default directory names patches this, although in the future you might consider other ways of not hardcoding directory names.

P.S. Great paper!